### PR TITLE
fix: padding site only when flash attention is used

### DIFF
--- a/app/models/rex_omni/wrapper.py
+++ b/app/models/rex_omni/wrapper.py
@@ -81,6 +81,7 @@ class RexOmniWrapper:
         """Initialize model and processor based on backend type"""
         print(f"Initializing {self.backend} backend...")
 
+        attn_implementation=kwargs.get("attn_implementation", None)
         if self.backend == "vllm":
             from transformers import AutoProcessor
             from vllm import LLM, SamplingParams
@@ -122,8 +123,9 @@ class RexOmniWrapper:
                 max_pixels=self.max_pixels,
             )
 
-            # Set padding side to left for batch inference with Flash Attention
-            self.processor.tokenizer.padding_side = "left"
+            if attn_implementation:
+                # Set padding side to left for batch inference with Flash Attention
+                self.processor.tokenizer.padding_side = "left"
 
             # Set up sampling parameters
             self.sampling_params = SamplingParams(
@@ -149,7 +151,7 @@ class RexOmniWrapper:
             self.model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
                 self.model_path,
                 torch_dtype=kwargs.get("torch_dtype", torch.bfloat16),
-                attn_implementation=kwargs.get("attn_implementation", None),
+                attn_implementation=attn_implementation,
                 device_map=kwargs.get("device_map", "auto"),
                 trust_remote_code=kwargs.get("trust_remote_code", True),
                 **{
@@ -173,8 +175,9 @@ class RexOmniWrapper:
                 use_fast=False,
             )
 
-            # Set padding side to left for batch inference with Flash Attention
-            self.processor.tokenizer.padding_side = "left"
+            if attn_implementation:
+                # Set padding side to left for batch inference with Flash Attention
+                self.processor.tokenizer.padding_side = "left"
 
             self.model_type = "transformers"
 

--- a/app/models/rexomni.py
+++ b/app/models/rexomni.py
@@ -36,14 +36,16 @@ class RexOmni(BaseModel):
         import torch
 
         init_kwargs = {
-            "device_map": device_map,
-            "torch_dtype": torch.bfloat16,
             "trust_remote_code": True,
         }
-        if attn_implementation is not None:
-            init_kwargs["attn_implementation"] = attn_implementation
 
-        if backend == "vllm":
+        if backend == "transformers":
+            init_kwargs.update({
+                "device_map": device_map,
+                "torch_dtype": torch.bfloat16,
+            })
+
+        elif backend == "vllm":
             init_kwargs.update(
                 {
                     "tokenizer_mode": self.params.get(
@@ -73,6 +75,7 @@ class RexOmni(BaseModel):
             repetition_penalty=self.params.get("repetition_penalty", 1.05),
             min_pixels=self.params.get("min_pixels", 16 * 28 * 28),
             max_pixels=self.params.get("max_pixels", 2560 * 28 * 28),
+            attn_implementation=attn_implementation,
             **init_kwargs,
         )
         self.task_type = TaskType


### PR DESCRIPTION
- Address issue https://github.com/CVHub520/X-AnyLabeling-Server/issues/18, we only set the padding side when Flash Attention is used in the config.
- Exclude unsupported parameters that prevent loading Rex-Omni in vLLM and transformers. Errors like below

> 2026-02-09 16:32:44.241 | ERROR    | app.core.registry:load_all_models | Failed to load model [rexomni]: EngineArgs.\_\_init\_\_() got an unexpected keyword argument 'device_map'

> 2026-02-09 17:13:47.975 | ERROR    | app.core.registry:load_all_models | Failed to load model [rexomni]: transformers.modeling_utils.PreTrainedModel.from_pretrained() got multiple values for keyword argument 'device_map'