### PR TITLE
fix(sam3): sam3 uses "cuda:{index}" in config file instead of hardcode "cuda" in code

### DIFF
--- a/app/models/sam3/model/position_encoding.py
+++ b/app/models/sam3/model/position_encoding.py
@@ -19,6 +19,7 @@ class PositionEmbeddingSine(nn.Module):
         temperature: int = 10000,
         normalize: bool = True,
         scale: Optional[float] = None,
+        device: str = "cuda",
         precompute_resolution: Optional[int] = None,
     ):
         super().__init__()
@@ -44,7 +45,7 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size, device=device)
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()

--- a/app/models/sam3/model_builder.py
+++ b/app/models/sam3/model_builder.py
@@ -66,13 +66,14 @@ def _setup_tf32() -> None:
 _setup_tf32()
 
 
-def _create_position_encoding(precompute_resolution=None):
+def _create_position_encoding(precompute_resolution=None, device="cuda"):
     """Create position encoding for visual backbone."""
     return PositionEmbeddingSine(
         num_pos_feats=256,
         normalize=True,
         scale=None,
         temperature=10000,
+        device=device,
         precompute_resolution=precompute_resolution,
     )
 
@@ -531,13 +532,13 @@ def _create_text_encoder(bpe_path: str) -> VETextEncoder:
 def _create_vision_backbone(
     compile_mode=None,
     enable_inst_interactivity=True,
-    image_size=SAM3_DEFAULT_IMAGE_SIZE,
+    image_size=SAM3_DEFAULT_IMAGE_SIZE,device="cuda"
 ) -> Sam3DualViTDetNeck:
     """Create SAM3 visual backbone with ViT and neck."""
     # Position encoding
     position_encoding = _create_position_encoding(
-        precompute_resolution=image_size
-    )
+        precompute_resolution=image_size, 
+        device=device)
     # ViT backbone
     vit_backbone: ViT = _create_vit_backbone(
         compile_mode=compile_mode,
@@ -605,8 +606,8 @@ def _load_checkpoint(model, checkpoint_path, drop_freqs_cis=False):
 
 def _setup_device_and_mode(model, device, eval_mode):
     """Setup model device and evaluation mode."""
-    if device == "cuda":
-        model = model.cuda()
+    if device.startswith("cuda"):
+        model = model.to(device)
     if eval_mode:
         model.eval()
     return model
@@ -651,6 +652,7 @@ def build_sam3_image_model(
         compile_mode=compile_mode,
         enable_inst_interactivity=enable_inst_interactivity,
         image_size=image_size,
+        device=device,
     )
 
     # Create text components
@@ -756,7 +758,7 @@ def build_sam3_video_model(
     )
 
     # Build Detector components
-    visual_neck = _create_vision_backbone(image_size=image_size)
+    visual_neck = _create_vision_backbone(image_size=image_size,device=device)
     text_encoder = _create_text_encoder(bpe_path)
     backbone = SAM3VLBackbone(scalp=1, visual=visual_neck, text=text_encoder)
     transformer = _create_sam3_transformer(

--- a/app/models/segment_anything_3.py
+++ b/app/models/segment_anything_3.py
@@ -31,7 +31,7 @@ class SegmentAnything3(BaseModel):
         self.image_size = self.params.get("image_size", 1008)
 
         if "cuda" in device and torch.cuda.is_available():
-            self.device = "cuda"
+            self.device = device
         else:
             self.device = "cpu"
             if "cuda" in device:
@@ -49,14 +49,14 @@ class SegmentAnything3(BaseModel):
             image_size=self.image_size,
         )
 
-        if self.device == "cuda" and torch.cuda.is_available():
+        if self.device.startswith("cuda") and torch.cuda.is_available():
             # turn on tfloat32 for Ampere GPUs
             # https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices
             torch.backends.cuda.matmul.allow_tf32 = True
             torch.backends.cudnn.allow_tf32 = True
 
             # use bfloat16 for the entire env. If your card doesn't support it, try float16 instead
-            torch.autocast("cuda", dtype=torch.bfloat16).__enter__()
+            torch.autocast(self.device, dtype=torch.bfloat16).__enter__()
 
             # inference mode for the whole env. Disable if you need gradients
             torch.inference_mode().__enter__()


### PR DESCRIPTION
sam3 的配置文件提供了 cuda:{index} 选项，但代码实现里面硬编码了 "cuda。

```yaml
params:
  bpe_path: "bpe_simple_vocab_16e6.txt.gz"
  model_path: "sam3.pt"
  device: "cuda:7"  # cuda:{index} or cpu
  image_size: 1008
  conf_threshold: 0.25
  show_boxes: false
  show_masks: true
  epsilon_factor: 0.001
```